### PR TITLE
To fix Issue#4, panel display

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "python.linting.enabled": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.linting.enabled": false
+}

--- a/octoprint_systemcommandeditor/__init__.py
+++ b/octoprint_systemcommandeditor/__init__.py
@@ -30,7 +30,8 @@ class SystemCommandEditorPlugin(octoprint.plugin.SettingsPlugin,
 		return dict(
 			js=["js/jquery.ui.sortable.js",
 				"js/systemcommandeditor.js",
-				"js/systemcommandeditorDialog.js"]
+				"js/systemcommandeditorDialog.js"],
+			css=["css/systemcommandeditor.css"]
 		)
 
 	def get_update_information(self):

--- a/octoprint_systemcommandeditor/static/css/systemcommandeditor.css
+++ b/octoprint_systemcommandeditor/static/css/systemcommandeditor.css
@@ -1,0 +1,3 @@
+#settings_plugin_systemcommandeditor {
+  min-height: 600px;
+}

--- a/octoprint_systemcommandeditor/templates/systemcommandeditor.jinja2
+++ b/octoprint_systemcommandeditor/templates/systemcommandeditor.jinja2
@@ -7,30 +7,30 @@
             <div class="control-group">
                 <label class="control-label">{{ _('Name') }}</label>
                 <div class="controls">
-                    <input style="width: 97%" data-bind="value: name"></input>
+                    <input style="width: 97%" data-bind="value: name" placeholder="Example: Shutdown"></input>
                 </div>
             </div>
             <div class="control-group">
                 <label class="control-label">{{ _('Action') }}</label>
                 <div class="controls">
-                    <input style="width: 97%" data-bind="value: action"></input>
+                    <input style="width: 97%" data-bind="value: action" placeholder="Example: shutdown"></input>
                 </div>
             </div>
             <div class="control-group">
                 <label class="control-label">{{ _('command') }}</label>
                 <div class="controls">
-                    <input style="width: 97%" data-bind="value: command"></input>
+                    <input style="width: 97%" data-bind="value: command" placeholder="Example: sudo shutdown -h now"></input>
                 </div>
             </div>
 
             <div class="control-group">
-                <label class="control-label"><input type="checkbox" data-bind="checked: $root.useConfirm"></input>{{ _('Use Confirmation') }}</label>
+                <label class="control-label"><input type="checkbox" data-bind="checked: $root.useConfirm"></input>&nbsp;{{ _('Use Confirmation') }}</label>
             </div>
             <!-- ko if: $root.useConfirm() -->
             <div class="control-group">
                 <label class="control-label">{{ _('Message') }}</label>
                 <div class="controls">
-                    <input style="width: 97%" data-bind="value: confirm"></input>
+                    <input style="width: 97%" data-bind="value: confirm" placeholder="Example: You are about to take the following action."></input>
                 </div>
             </div>
             <!-- /ko -->

--- a/octoprint_systemcommandeditor/templates/systemcommandeditor_hookedsettings.jinja2
+++ b/octoprint_systemcommandeditor/templates/systemcommandeditor_hookedsettings.jinja2
@@ -1,7 +1,8 @@
 <h4>System Command Editor</h4>
 
+<p><small>Right-mouse click the section below for available options.</small></p>
 <div class="dropdown open">
-    <ul class="dropdown-menu" id="systemActions">
+    <ul class="dropdown-menu" id="systemActions" title="Right-mouse click for actions">
         <li class="static" style="min-height:15px; margin: 16px 16px; border:1px solid #00e500" id="base" data-bind="contextMenu: { menuSelector: '#SystemCommandEditor_systemContextMenu1', menuSelected: $root.systemContextMenu }"></li>
         <!-- ko foreach: systemActions -->
             <!-- ko ifnot: action().startsWith("divider") -->


### PR DESCRIPTION
This PR is designed to address Issue#4 on your repository as well as the related issues as described in the OctoPrint forum thread [here](https://discourse.octoprint.org/t/system-command-editor-plugin-not-working/956?u=outsourcedguru).

* Adjusted style of the outer-most DIV tag to have a minimum height, required when you're under the control of OctoPrint's `scrollable` class.
* Added a stylesheet to your project.
* Added `placeholder` text for your input tags so that people can more easily determine what each does.
* Added a `title` attribute to the green rectangle UL element so that people know to right-mouse click it.
* Added a `p` element to further make this known to your users how this works.

Tested in the latest Safari and seems to behave even under the Themeify -> Discorded theme.